### PR TITLE
Fix and Rename `chaldal` website

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -128,8 +128,8 @@ https://www.facebook.com/craftsmenltd/[Facebook]
 |Chaldal Engineering
 |House 6, Road 9, Block C, Banani
 |.NET, F#, C#, SQL Server, TypeScript, JavaScript, Xamarin, Android, React, React Native, Microsoft Orleans
-|https://chaldal.tech/[Engineering Website],
-https://chaldal.com/t/Career/[Career Website]
+|https://chaldal.tech/[Engineering and Career Website],
+https://chaldal.com/[Main Website]
 
 |Chumbok IT
 |_Remote_


### PR DESCRIPTION
The career page website link that was provided here previously was not working. I think they have changed their address. Now Engineering website is their Career site also. Their main site is `chaldal.com`. So, I have renamed it.